### PR TITLE
修复Stripe支付的汇率转换API

### DIFF
--- a/app/Payments/StripeCheckout.php
+++ b/app/Payments/StripeCheckout.php
@@ -132,7 +132,7 @@ class StripeCheckout {
 
     private function exchange($from, $to)
     {
-        $result = file_get_contents('https://api.exchangerate.host/latest?symbols=' . $to . '&base=' . $from);
+        $result = file_get_contents("https://api.exchangerate-api.com/v4/latest/{$from}");
         $result = json_decode($result, true);
         return $result['rates'][$to];
     }

--- a/app/Payments/StripeCredit.php
+++ b/app/Payments/StripeCredit.php
@@ -117,7 +117,7 @@ class StripeCredit {
 
     private function exchange($from, $to)
     {
-        $result = file_get_contents('https://api.exchangerate.host/latest?symbols=' . $to . '&base=' . $from);
+        $result = file_get_contents("https://api.exchangerate-api.com/v4/latest/{$from}");
         $result = json_decode($result, true);
         return $result['rates'][$to];
     }


### PR DESCRIPTION
之前的API地址已不可用，使用Stripe支付时会报错。