### PR TITLE
根据Telegram的要求，要生成https链接

### DIFF
--- a/app/Http/Controllers/V1/Admin/ConfigController.php
+++ b/app/Http/Controllers/V1/Admin/ConfigController.php
@@ -57,7 +57,7 @@ class ConfigController extends Controller
 
     public function setTelegramWebhook(Request $request)
     {
-        $hookUrl = url('/api/v1/guest/telegram/webhook?access_token=' . md5(config('v2board.telegram_bot_token', $request->input('telegram_bot_token'))));
+        $hookUrl = secure_url('/api/v1/guest/telegram/webhook?access_token=' . md5(config('v2board.telegram_bot_token', $request->input('telegram_bot_token'))));
         $telegramService = new TelegramService($request->input('telegram_bot_token'));
         $telegramService->getMe();
         $telegramService->setWebhook($hookUrl);


### PR DESCRIPTION
否则可能出现
来自TG的错误：Bad Request: bad webhook: An HTTPS URL must be provided for webhook