### PR TITLE
feat: Add Hysteria 2 Obfs config for Loon

### DIFF
--- a/app/Protocols/Loon.php
+++ b/app/Protocols/Loon.php
@@ -237,6 +237,9 @@ class Loon
         if (!empty($server['insecure'])) {
             array_push($config, $server['insecure'] ? 'skip-cert-verify=true' : 'skip-cert-verify=false');
         }
+        if (isset($server['obfs'])){
+            array_push($config, 'salamander-password=' . $server['obfs_password']);
+        }
         $config = array_filter($config);
         $uri = implode(',', $config);
         $uri .= "\r\n";


### PR DESCRIPTION
为 Loon 添加了适用于 Salamander 混淆的密码配置。

同时很奇怪地发现：Stash, Surge 等 iOS 平台 App 均在支持 Hysteria 2 的前提下不支持 Obfs 功能。