### PR TITLE
Update KnowledgeController.php 为知识库添加Token变量名

### DIFF
--- a/app/Http/Controllers/V1/User/KnowledgeController.php
+++ b/app/Http/Controllers/V1/User/KnowledgeController.php
@@ -37,6 +37,7 @@ class KnowledgeController extends Controller
                 ),
                 $knowledge['body']
             );
+            $knowledge['body'] = str_replace('{{subscribeToken}}', $user['token'], $knowledge['body']);
             return response([
                 'data' => $knowledge
             ]);


### PR DESCRIPTION
在[此处](https://github.com/wyx2685/v2board/blob/master/app/Http/Controllers/V1/User/KnowledgeController.php#L28-L39)添加一行变量替换
```php
$knowledge['body'] = str_replace('{{subscribeToken}}', $user['token'], $knowledge['body']); 
```
这样编辑知识库的时候可以引用 `{{subscribeToken}}` 来更方便地实现添加不同域名订阅链接的复制按钮

![2025-07-09_10-12-09_chrome](https://github.com/user-attachments/assets/36faffc0-ec2a-48ab-a40c-58eb4dec70cb)
