### PR TITLE
fix: 修复今日收入中统计了佣金划转余额的问题

### DIFF
--- a/app/Http/Controllers/V1/Admin/StatController.php
+++ b/app/Http/Controllers/V1/Admin/StatController.php
@@ -49,6 +49,10 @@ class StatController extends Controller
                 'day_income' => Order::where('created_at', '>=', strtotime(date('Y-m-d')))
                     ->where('created_at', '<', time())
                     ->whereNotIn('status', [0, 2])
+                    ->where(function($query) {
+                        $query->where('type', '!=', 9)
+                            ->orWhereNotNull('callback_no');
+                    })
                     ->sum('total_amount'),
                 'last_month_income' => Order::where('created_at', '>=', strtotime('-1 month', strtotime(date('Y-m-1'))))
                     ->where('created_at', '<', strtotime(date('Y-m-1')))


### PR DESCRIPTION
通过佣金划转的余额与用户直接充值的余额在订单记录中为同一类别
但是通过佣金划转余额不存在来自支付渠道的callback_no
故根据是否存在callback_no来判断来自余额的订单是否需要计入统计