### PR TITLE
更严谨的sendEmailVerify场景划分.

### DIFF
--- a/app/Http/Controllers/V1/Passport/CommController.php
+++ b/app/Http/Controllers/V1/Passport/CommController.php
@@ -46,26 +46,25 @@ class CommController extends Controller
         $email = $request->input('email');
         $isforget = $request->input('isforget');
         $email_exists = User::where('email', $email)->exists();
-        //检查是否在白名单内
-        if (isset($isforget)) {
-            if($isforget == 0){
-                if ((int)config('v2board.email_whitelist_enable', 0)) {
-                    if (!Helper::emailSuffixVerify(
-                        $request->input('email'),
-                        config('v2board.email_whitelist_suffix', Dict::EMAIL_WHITELIST_SUFFIX_DEFAULT))
-                    ) {
-                        abort(500, __('Email suffix is not in the Whitelist'));
-                    }
-                }
-                // 检查是否是gmail别名邮箱
-                if ((int)config('v2board.email_gmail_limit_enable', 0)) {
-                    $prefix = explode('@', $request->input('email'))[0];
-                    if (strpos($prefix, '.') !== false || strpos($prefix, '+') !== false) {
-                        abort(500, __('Gmail alias is not supported'));
-                    }
+        if($isforget !== 1){
+            if ((int)config('v2board.email_whitelist_enable', 0)) {
+                if (!Helper::emailSuffixVerify(
+                    $request->input('email'),
+                    config('v2board.email_whitelist_suffix', Dict::EMAIL_WHITELIST_SUFFIX_DEFAULT))
+                ) {
+                    abort(500, __('Email suffix is not in the Whitelist'));
                 }
             }
-            
+            // 检查是否是gmail别名邮箱
+            if ((int)config('v2board.email_gmail_limit_enable', 0)) {
+                $prefix = explode('@', $request->input('email'))[0];
+                if (strpos($prefix, '.') !== false || strpos($prefix, '+') !== false) {
+                    abort(500, __('Gmail alias is not supported'));
+                }
+            }
+        }
+        //检查是否在白名单内
+        if (isset($isforget)) {
             if ($isforget == 0 && $email_exists) {
                 abort(500, __('This email is registered'));
             } 


### PR DESCRIPTION
如果是未开启emailSuffixVerify或gmail别名验证前注册的账户,  开启后, 在忘记密码中无法通过emailSuffixVerify与gmail别名验证.