### PR TITLE
解决clash下发订阅时，没有tls就忽略flow参数的bug

### DIFF
--- a/app/Protocols/ClashMeta.php
+++ b/app/Protocols/ClashMeta.php
@@ -225,11 +225,14 @@ class ClashMeta
         $array['uuid'] = $uuid;
         $array['udp'] = true;
 
+        if (!empty($server['flow'])) {
+            $array['flow'] = $server['flow'];
+        }
+
         if ($server['tls']) {
             $array['tls'] = true;
             $tlsSettings = $server['tls_settings'] ?? [];
             $array['skip-cert-verify'] = ($tlsSettings['allow_insecure'] ?? 0) == 1 ? true : false;
-            $array['flow'] = !empty($server['flow']) ? $server['flow']: "";
             $array['client-fingerprint'] = !empty($tlsSettings['fingerprint']) ? $tlsSettings['fingerprint'] : 'chrome';
             if ($tlsSettings) {
                 if (isset($tlsSettings['server_name']) && !empty($tlsSettings['server_name']))

--- a/app/Protocols/ClashVerge.php
+++ b/app/Protocols/ClashVerge.php
@@ -225,11 +225,14 @@ class ClashVerge
         $array['uuid'] = $uuid;
         $array['udp'] = true;
 
+        if (!empty($server['flow'])) {
+            $array['flow'] = $server['flow'];
+        }
+
         if ($server['tls']) {
             $array['tls'] = true;
             $tlsSettings = $server['tls_settings'] ?? [];
             $array['skip-cert-verify'] = ($tlsSettings['allow_insecure'] ?? 0) == 1 ? true : false;
-            $array['flow'] = !empty($server['flow']) ? $server['flow']: "";
             $array['client-fingerprint'] = !empty($tlsSettings['fingerprint']) ? $tlsSettings['fingerprint'] : 'chrome';
             if ($tlsSettings) {
                 if (isset($tlsSettings['server_name']) && !empty($tlsSettings['server_name']))


### PR DESCRIPTION
修复bug: 当使用协议是vless+tcp+encryption+xtls vison时，原代码检测到没有tls将直接丢弃flow参数