### PR TITLE
fix: cast xPaddingObfsMode to bool when saving xhttp network settings

### DIFF
--- a/app/Http/Controllers/V1/Admin/Server/V2nodeController.php
+++ b/app/Http/Controllers/V1/Admin/Server/V2nodeController.php
@@ -71,6 +71,9 @@ class V2nodeController extends Controller
             if (isset($ns['acceptProxyProtocol'])) {
                 $ns['acceptProxyProtocol'] = filter_var($ns['acceptProxyProtocol'], FILTER_VALIDATE_BOOLEAN);
             }
+            if (isset($ns['xPaddingObfsMode'])) {
+                $ns['xPaddingObfsMode'] = filter_var($ns['xPaddingObfsMode'], FILTER_VALIDATE_BOOLEAN);
+            }
             $params['network_settings'] = $ns;
         }
         if ($params['network'] != 'tcp' && isset($params['encryption']) && $params['encryption'] != 'mlkem768x25519plus') {
@@ -85,6 +88,9 @@ class V2nodeController extends Controller
                 }
                 if (isset($extra['noSSEHeader'])) {
                     $extra['noSSEHeader'] = filter_var($extra['noSSEHeader'], FILTER_VALIDATE_BOOLEAN);
+                }
+                if (isset($extra['xPaddingObfsMode'])) {
+                    $extra['xPaddingObfsMode'] = filter_var($extra['xPaddingObfsMode'], FILTER_VALIDATE_BOOLEAN);
                 }
                 if (isset($extra['scMaxBufferedPosts'])) {
                     $extra['scMaxBufferedPosts'] = (int)$extra['scMaxBufferedPosts'];
@@ -104,6 +110,9 @@ class V2nodeController extends Controller
                     $extra['downloadSettings'] = $downloadSettings;
                 }
                 $ns['extra'] = $extra;
+            }
+            if (isset($ns['xPaddingObfsMode'])) {
+                $ns['xPaddingObfsMode'] = filter_var($ns['xPaddingObfsMode'], FILTER_VALIDATE_BOOLEAN);
             }
             $params['network_settings'] = $ns;
         }

--- a/app/Http/Controllers/V1/Admin/Server/VlessController.php
+++ b/app/Http/Controllers/V1/Admin/Server/VlessController.php
@@ -62,6 +62,9 @@ class VlessController extends Controller
                 if (isset($extra['noSSEHeader'])) {
                     $extra['noSSEHeader'] = filter_var($extra['noSSEHeader'], FILTER_VALIDATE_BOOLEAN);
                 }
+                if (isset($extra['xPaddingObfsMode'])) {
+                    $extra['xPaddingObfsMode'] = filter_var($extra['xPaddingObfsMode'], FILTER_VALIDATE_BOOLEAN);
+                }
                 if (isset($extra['scMaxBufferedPosts'])) {
                     $extra['scMaxBufferedPosts'] = (int)$extra['scMaxBufferedPosts'];
                 }
@@ -80,6 +83,9 @@ class VlessController extends Controller
                     $extra['downloadSettings'] = $downloadSettings;
                 }
                 $ns['extra'] = $extra;
+            }
+            if (isset($ns['xPaddingObfsMode'])) {
+                $ns['xPaddingObfsMode'] = filter_var($ns['xPaddingObfsMode'], FILTER_VALIDATE_BOOLEAN);
             }
             $params['network_settings'] = $ns;
         }


### PR DESCRIPTION
## Summary
  This PR fixes a type mismatch when saving `xhttp` network settings by explicitly casting `xPaddingObfsMode` to `bool`.

  ## Problem
  When `xhttp` settings are submitted from the admin panel, `xPaddingObfsMode` may be stored as a string value such as `"true"` or `"false"` instead of a native boolean.

  This can cause clients or `v2node` to fail at startup when loading the generated configuration, with errors like:

  ```text
  error: add new node
  error: build inbound error: infra/conf: Failed to build XHTTP config.
  > infra/conf: Failed to unmarshal "extra".
  > json: cannot unmarshal string into Go struct field SplitHTTPConfig.xPaddingObfsMode of type bool
```
  ## Root Cause

  xPaddingObfsMode is a boolean field in the XHTTP config, but the saved payload could contain a string value. When the config is later parsed by the client or v2node, Go JSON unmarshalling rejects the string because it expects a boolean.

  ## Changes

  - Cast network_settings.xPaddingObfsMode to bool before saving.
  - Cast network_settings.extra.xPaddingObfsMode to bool before saving.
  - Apply the same normalization in both V2nodeController and VlessController.

  ## Impact

  This ensures xhttp settings are stored with the correct data type and fixes startup failures caused by invalid xPaddingObfsMode values in generated configs.

  ## Testing

  - Verified that xPaddingObfsMode is normalized with filter_var(..., FILTER_VALIDATE_BOOLEAN) before persistence.
  - Confirmed the fix is applied to both top-level network_settings and nested network_settings.extra.