### PR TITLE
解决使用PHP-8.0版本时，节点无人在线数据库v2_log增加报错的问题

### DIFF
--- a/app/Http/Controllers/V1/Server/UniProxyController.php
+++ b/app/Http/Controllers/V1/Server/UniProxyController.php
@@ -134,6 +134,12 @@ class UniProxyController extends Controller
                 'error' => 'Invalid online data format'
             ], 400);
         }
+
+    // 如果上报的在线数据为空，说明此时0人在线，直接返回成功，不去折腾 Redis
+        if (empty($data)) {
+            return response(['data' => true]);
+        }
+
         $updateAt = time();
         $cacheKeys = array_map(function ($uid) {
             return 'ALIVE_IP_USER_' . $uid;


### PR DESCRIPTION
## PR 标题

`fix(server): 修复节点0人在线时上报空数据触发 Redis mget 报错`

---

## 问题描述

当后端代理节点**0人在线**时，会向面板心跳接口（`/api/v1/server/UniProxy/alive`）上报空数组 `[]`。由于 `UniProxyController.php` 缺乏对空数据的有效拦截，程序直接带着空列表调用了 `Cache::many()`。这导致向 Redis 发起了不带参数的 `mget` 请求，从而引发系统崩溃。

该 Bug 会导致数据库 `v2_log` 表在短时间内堆积数万条重复报错，严重消耗服务器磁盘空间和 MySQL 读写性能。

### 核心报错内容

* **Predis 驱动下报错：**
```text
ERR wrong number of arguments for 'mget' command

```


* **PhpRedis 驱动（PHP 8.0 及以上环境）下报错：**

```text
    array_map(): Argument #2 ($array) must be of type array, bool given
```


## 修改方案
在 `UniProxyController@alive` 接口中增加空数据拦截。如果检测到当前无人在线（`$data` 为空），则直接响应成功并结束流程，提前拦截，不再向 Redis 发起无效请求：

```php
if (empty($data)) {
    return response(['data' => true]);
}
 ```

---

## 测试结果

* **无人在线时：** 节点心跳正常，数据库 `v2_log` 错误日志彻底停止增加。
* **有人在线时：** 用户流量统计、在线 IP 追踪以及设备数限制功能一切正常。

```

```