### PR TITLE
Update UniProxyController.php by codex

### DIFF
--- a/app/Http/Controllers/V1/Server/UniProxyController.php
+++ b/app/Http/Controllers/V1/Server/UniProxyController.php
@@ -129,6 +129,11 @@ class UniProxyController extends Controller
         if (empty($data)) {
             $data = $_POST;
         }
+        if (empty($data)) {
+            return response([
+                'data' => true
+            ]);
+        }
         if (!is_array($data)) {
             return response([
                 'error' => 'Invalid online data format'
@@ -138,6 +143,12 @@ class UniProxyController extends Controller
         $cacheKeys = array_map(function ($uid) {
             return 'ALIVE_IP_USER_' . $uid;
         }, array_keys($data));
+
+        if (empty($cacheKeys)) {
+            return response([
+                'data' => true
+            ]);
+        }
 
         $cachedData = Cache::many($cacheKeys);
         $updates = [];

--- a/app/Protocols/Singbox/Singbox.php
+++ b/app/Protocols/Singbox/Singbox.php
@@ -376,44 +376,74 @@ class Singbox
             ],
             'server_name' => $server['server_name'] ?? ($tlsSettings['server_name'] ?? '')
         ];
-        if ($server['tls_settings']) {
-            if ($server['tls'] == 2) {
+
+        if (!empty($tlsSettings)) {
+            if (($server['tls'] ?? 0) == 2) {
                 $tlsConfig['reality'] = [
                     'enabled' => true,
-                    'public_key' => $tlsSettings['public_key'],
-                    'short_id' => $tlsSettings['short_id']
+                    'public_key' => $tlsSettings['public_key'] ?? '',
+                    'short_id' => $tlsSettings['short_id'] ?? ''
                 ];
             }
+
             $tlsConfig['utls'] = [
-                "enabled" => true,
-                "fingerprint" => $tlsSettings['fingerprint'] ?? 'chrome'
+                'enabled' => true,
+                'fingerprint' => $tlsSettings['fingerprint'] ?? 'chrome'
             ];
         }
+
         $array['tls'] = $tlsConfig;
 
-        if ($server['network'] === 'tcp') {
-            $tcpSettings = $server['network_settings'];
-            if (isset($tcpSettings['header']['type']) && $tcpSettings['header']['type'] == 'http') $array['transport']['type'] = $tcpSettings['header']['type'];
-            if (isset($tcpSettings['header']['request']['headers']['Host'])) $array['transport']['host'] = $tcpSettings['header']['request']['headers']['Host'];
-            if (isset($tcpSettings['header']['request']['path'][0])) $array['transport']['path'] = $tcpSettings['header']['request']['path'][0];
+        $network = $server['network'] ?? 'tcp';
+        $networkSettings = $server['network_settings'] ?? [];
+
+        if ($network === 'tcp') {
+            $tcpSettings = $networkSettings;
+
+            if (isset($tcpSettings['header']['type']) && $tcpSettings['header']['type'] == 'http') {
+                $array['transport']['type'] = $tcpSettings['header']['type'];
+            }
+
+            if (isset($tcpSettings['header']['request']['headers']['Host'])) {
+                $array['transport']['host'] = $tcpSettings['header']['request']['headers']['Host'];
+            }
+
+            if (isset($tcpSettings['header']['request']['path'][0])) {
+                $array['transport']['path'] = $tcpSettings['header']['request']['path'][0];
+            }
         }
-        if ($server['network'] === 'ws') {
-            $array['transport']['type'] ='ws';
-            if ($server['network_settings']) {
-                $wsSettings = $server['network_settings'];
-                if (isset($wsSettings['path']) && !empty($wsSettings['path'])) $array['transport']['path'] = $wsSettings['path'];
-                if (isset($wsSettings['headers']['Host']) && !empty($wsSettings['headers']['Host'])) $array['transport']['headers'] = ['Host' => array($wsSettings['headers']['Host'])];
+
+        if ($network === 'ws') {
+            $array['transport']['type'] = 'ws';
+
+            if (!empty($networkSettings)) {
+                $wsSettings = $networkSettings;
+
+                if (isset($wsSettings['path']) && !empty($wsSettings['path'])) {
+                    $array['transport']['path'] = $wsSettings['path'];
+                }
+
+                if (isset($wsSettings['headers']['Host']) && !empty($wsSettings['headers']['Host'])) {
+                    $array['transport']['headers'] = ['Host' => [$wsSettings['headers']['Host']]];
+                }
+
                 $array['transport']['max_early_data'] = 2048;
                 $array['transport']['early_data_header_name'] = 'Sec-WebSocket-Protocol';
             }
         }
-        if ($server['network'] === 'grpc') {
-            $array['transport']['type'] ='grpc';
-            if ($server['network_settings']) {
-                $grpcSettings = $server['network_settings'];
-                if (isset($grpcSettings['serviceName'])) $array['transport']['service_name'] = $grpcSettings['serviceName'];
+
+        if ($network === 'grpc') {
+            $array['transport']['type'] = 'grpc';
+
+            if (!empty($networkSettings)) {
+                $grpcSettings = $networkSettings;
+
+                if (isset($grpcSettings['serviceName'])) {
+                    $array['transport']['service_name'] = $grpcSettings['serviceName'];
+                }
             }
         }
+
         return $array;
     }
 

--- a/resources/rules/default.sing-box.json
+++ b/resources/rules/default.sing-box.json
@@ -6,9 +6,12 @@
                 "tag": "local"
             },
             {
-                "type": "udp",
+                "type": "https",
                 "tag": "remote",
-                "server": "1.1.1.1"
+                "server": "1.1.1.1",
+                "server_port": 443,
+                "path": "/dns-query",
+                "detour": "节点选择"
             },
             {
                 "type": "udp",
@@ -17,6 +20,13 @@
             }
         ],
         "rules": [
+            {
+                "rule_set": [
+                    "geosite-geolocation-!cn"
+                ],
+                "action": "route",
+                "server": "remote"
+            },
             {
                 "rule_set": [
                     "geosite-cn"
@@ -32,8 +42,7 @@
             "tag": "tun-in",
             "type": "tun",
             "address": [
-                "172.19.0.1/30",
-                "2001:0470:f9da:fdfa::1/64"
+                "172.19.0.1/30"
             ],
             "auto_route": true,
             "mtu": 9000,


### PR DESCRIPTION
v2_log表炸到50多G。以下为codex回复：

仔细看了，根因基本确定：后端节点在请求 /UniProxy/alive，但提交的在线数据为空或格式不对，导致 $cacheKeys=[]，然后 Cache::many([]) 调 Redis mget([])，phpredis 返回 false，Laravel 再 array_map(false) 报错。 日志还在增长，433→443→452，说明问题持续发生。
真正问题是：很多节点的 /UniProxy/alive 上报触发了同一个 Laravel Redis Cache::many() 报错。建议按我上一条，在 Cache::many($cacheKeys) 前加空数组判断。
