### PR TITLE
Update UniProxyController.php by codex

### DIFF
--- a/app/Http/Controllers/V1/Server/UniProxyController.php
+++ b/app/Http/Controllers/V1/Server/UniProxyController.php
@@ -129,6 +129,11 @@ class UniProxyController extends Controller
         if (empty($data)) {
             $data = $_POST;
         }
+        if (empty($data)) {
+            return response([
+                'data' => true
+            ]);
+        }
         if (!is_array($data)) {
             return response([
                 'error' => 'Invalid online data format'
@@ -138,6 +143,12 @@ class UniProxyController extends Controller
         $cacheKeys = array_map(function ($uid) {
             return 'ALIVE_IP_USER_' . $uid;
         }, array_keys($data));
+
+        if (empty($cacheKeys)) {
+            return response([
+                'data' => true
+            ]);
+        }
 
         $cachedData = Cache::many($cacheKeys);
         $updates = [];


### PR DESCRIPTION
v2_log表炸到50多G。以下为codex回复：

仔细看了，根因基本确定：后端节点在请求 /UniProxy/alive，但提交的在线数据为空或格式不对，导致 $cacheKeys=[]，然后 Cache::many([]) 调 Redis mget([])，phpredis 返回 false，Laravel 再 array_map(false) 报错。 日志还在增长，433→443→452，说明问题持续发生。 真正问题是：很多节点的 /UniProxy/alive 上报触发了同一个 Laravel Redis Cache::many() 报错。建议按我上一条，在 Cache::many($cacheKeys) 前加空数组判断。