### PR TITLE
按中国节假日/工作时间动态决定是否强制邀请码

### DIFF
--- a/app/Http/Controllers/V1/Guest/CommController.php
+++ b/app/Http/Controllers/V1/Guest/CommController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\V1\Guest;
 
 use App\Http\Controllers\Controller;
+use App\Services\RegisterPolicyService;
 use App\Utils\Dict;
 use Illuminate\Support\Facades\Http;
 
@@ -14,7 +15,10 @@ class CommController extends Controller
             'data' => [
                 'tos_url' => config('v2board.tos_url'),
                 'is_email_verify' => (int)config('v2board.email_verify', 0) ? 1 : 0,
-                'is_invite_force' => (int)config('v2board.invite_force', 0) ? 1 : 0,
+                // 邀请码是否强制：按节假日 / 工作时间动态判断，见 RegisterPolicyService。
+                // 前端读这个字段决定注册表单那一栏是不是必填；
+                // AuthController@register 用的是同一个方法，两边不会打架。
+                'is_invite_force' => RegisterPolicyService::inviteForce() ? 1 : 0,
                 'email_whitelist_suffix' => (int)config('v2board.email_whitelist_enable', 0)
                     ? $this->getEmailSuffix()
                     : 0,

--- a/app/Http/Controllers/V1/Passport/AuthController.php
+++ b/app/Http/Controllers/V1/Passport/AuthController.php
@@ -11,6 +11,7 @@ use App\Models\InviteCode;
 use App\Models\Plan;
 use App\Models\User;
 use App\Services\AuthService;
+use App\Services\RegisterPolicyService;
 use App\Utils\CacheKey;
 use App\Utils\Dict;
 use App\Utils\Helper;
@@ -54,7 +55,11 @@ class AuthController extends Controller
         if ((int)config('v2board.stop_register', 0)) {
             abort(500, __('Registration has closed'));
         }
-        if ((int)config('v2board.invite_force', 0)) {
+        /* 邀请码是否强制：按节假日 / 工作时间动态判断，见 RegisterPolicyService。
+           一次请求内只算一次，下面「码无效」那处判断要用同一个结果 ——
+           两处用不同的值会出现「不强制却因为码填错被拒」这种矛盾行为。 */
+        $inviteForce = RegisterPolicyService::inviteForce();
+        if ($inviteForce) {
             if (empty($request->input('invite_code'))) {
                 abort(500, __('You must use the invitation code to register'));
             }
@@ -86,7 +91,8 @@ class AuthController extends Controller
                 ->where('status', 0)
                 ->first();
             if (!$inviteCode) {
-                if ((int)config('v2board.invite_force', 0)) {
+                // 用上面算好的同一个值：不强制的时段填错码只是忽略，不拦人
+                if ($inviteForce) {
                     abort(500, __('Invalid invitation code'));
                 }
             } else {

--- a/app/Services/RegisterPolicyService.php
+++ b/app/Services/RegisterPolicyService.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * 注册策略：按中国的节假日 / 工作时间决定要不要强制邀请码。
+ *
+ * 这套判断必须放后端。前端只能决定「要不要显示那个输入框」，
+ * 而 POST /api/v1/passport/auth/register 是公开接口，谁都能直接打；
+ * 前端还依赖用户设备时钟，改个系统时间就绕过了。
+ *
+ * 用法：CommController@config 和 AuthController@register 都调 inviteForce()，
+ * 两边用同一个判断，前端界面和后端校验才不会打架。
+ */
+class RegisterPolicyService
+{
+    /** 判定时区。服务器在境外，绝不能靠 date() 的默认时区 */
+    private const TZ = 'Asia/Shanghai';
+
+    /** 强制邀请码的时间窗，24 小时制，含头不含尾（09:00 起，18:00 止） */
+    private const WORK_START = 9;
+    private const WORK_END   = 18;
+
+    /** 节假日数据缓存时长（秒） */
+    private const CACHE_TTL = 86400;
+
+    /**
+     * 当前这一刻是否强制邀请码。
+     *
+     *   后台开关关着                        → 不强制（整套规则不生效）
+     *   法定节假日                          → 不强制
+     *   周一至周五 09:00–18:00（非节假日）  → 强制
+     *   其余时间（周末、工作日的早晚）      → 不强制
+     *
+     * 最后一条是默认值：需求只定义了「节假日」和「工作日白天」两种情况，
+     * 周末和工作日晚上没说，这里按「不强制」处理。要改就动下面的 return。
+     *
+     * 注意：调休补班的周六周日仍然按周末处理（不强制）。需求写的是
+     * 「星期一到星期五」，这里照字面执行。想让补班日也算工作日的话，
+     * 把 $dow > 5 那段换成读 isOffDay === false 的判断。
+     */
+    public static function inviteForce(?\DateTimeInterface $at = null): bool
+    {
+        // 后台那个开关当总闸：关掉就完全按原来的来，规则不介入，出问题能一键回退
+        if (!(int)config('v2board.invite_force', 0)) {
+            return false;
+        }
+
+        /* $at 只给测试用，生产调用不传就是「现在」。
+           统一先转成时间戳再套上海时区：不管传进来的是什么时区，
+           换算出的北京时间都是对的。 */
+        $now = new \DateTime('@' . ($at ? $at->getTimestamp() : time()));
+        $now->setTimezone(new \DateTimeZone(self::TZ));
+
+        $date = $now->format('Y-m-d');
+
+        if (self::isOffDay($date)) {
+            return false;
+        }
+
+        $dow = (int)$now->format('N');          // 1=周一 … 7=周日
+        if ($dow > 5) {
+            return false;
+        }
+
+        $hour = (int)$now->format('G');         // 0-23，无前导零
+        return $hour >= self::WORK_START && $hour < self::WORK_END;
+    }
+
+    /**
+     * 查当天是不是法定放假日。
+     *
+     * 数据放本地 JSON，不在注册接口里同步调第三方 API —— 那会让注册变慢，
+     * 而且对方一挂你的注册就跟着挂。
+     *
+     * 文件格式用 holiday-cn（github.com/NateScarlet/holiday-cn）那套：
+     *   { "days": [ { "date": "2026-01-01", "name": "元旦", "isOffDay": true }, ... ] }
+     * isOffDay=true 是放假，false 是调休上班。文件里只列特殊日子，
+     * 普通周末不在里面。
+     *
+     * 放在 storage/app/holidays/{年份}.json，每年 12 月国务院发文后更新一次。
+     */
+    private static function isOffDay(string $date): bool
+    {
+        $year = substr($date, 0, 4);
+        $map  = self::holidayMap($year);
+
+        return ($map[$date] ?? false) === true;
+    }
+
+    /**
+     * 读取并缓存某一年的节假日表，返回 [ 'Y-m-d' => bool isOffDay ]。
+     *
+     * 只缓存成功结果。读失败也缓存的话，你把文件补上或改好权限之后，
+     * 还得等一整天才生效 —— 排查时很容易被这个绕进去。
+     */
+    private static function holidayMap(string $year): array
+    {
+        $key = "holiday_cn_{$year}";
+        $map = Cache::get($key);
+        if (is_array($map)) {
+            return $map;
+        }
+
+        $file = storage_path("app/holidays/{$year}.json");
+
+        if (!is_file($file) || !is_readable($file)) {
+            // 不缓存，下次请求还会再试一次
+            Log::warning("[RegisterPolicy] 节假日数据不可读，本年度按无节假日处理：{$file}");
+            return [];
+        }
+
+        $raw  = @file_get_contents($file);
+        $json = $raw === false ? null : json_decode($raw, true);
+
+        if (!is_array($json) || empty($json['days']) || !is_array($json['days'])) {
+            Log::warning("[RegisterPolicy] 节假日数据格式不对（缺 days 数组）：{$file}");
+            return [];
+        }
+
+        $map = [];
+        foreach ($json['days'] as $d) {
+            if (is_array($d) && !empty($d['date'])) {
+                $map[$d['date']] = !empty($d['isOffDay']);
+            }
+        }
+
+        Cache::put($key, $map, self::CACHE_TTL);
+        return $map;
+    }
+}

--- a/storage/app/holidays/2026.json
+++ b/storage/app/holidays/2026.json
@@ -1,0 +1,205 @@
+{
+    "$schema": "https://raw.githubusercontent.com/NateScarlet/holiday-cn/master/schema.json",
+    "$id": "https://raw.githubusercontent.com/NateScarlet/holiday-cn/master/2026.json",
+    "year": 2026,
+    "papers": [
+        "https://www.gov.cn/zhengce/zhengceku/202511/content_7047091.htm"
+    ],
+    "days": [
+        {
+            "name": "元旦",
+            "date": "2026-01-01",
+            "isOffDay": true
+        },
+        {
+            "name": "元旦",
+            "date": "2026-01-02",
+            "isOffDay": true
+        },
+        {
+            "name": "元旦",
+            "date": "2026-01-03",
+            "isOffDay": true
+        },
+        {
+            "name": "元旦",
+            "date": "2026-01-04",
+            "isOffDay": false
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-14",
+            "isOffDay": false
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-15",
+            "isOffDay": true
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-16",
+            "isOffDay": true
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-17",
+            "isOffDay": true
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-18",
+            "isOffDay": true
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-19",
+            "isOffDay": true
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-20",
+            "isOffDay": true
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-21",
+            "isOffDay": true
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-22",
+            "isOffDay": true
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-23",
+            "isOffDay": true
+        },
+        {
+            "name": "春节",
+            "date": "2026-02-28",
+            "isOffDay": false
+        },
+        {
+            "name": "清明节",
+            "date": "2026-04-04",
+            "isOffDay": true
+        },
+        {
+            "name": "清明节",
+            "date": "2026-04-05",
+            "isOffDay": true
+        },
+        {
+            "name": "清明节",
+            "date": "2026-04-06",
+            "isOffDay": true
+        },
+        {
+            "name": "劳动节",
+            "date": "2026-05-01",
+            "isOffDay": true
+        },
+        {
+            "name": "劳动节",
+            "date": "2026-05-02",
+            "isOffDay": true
+        },
+        {
+            "name": "劳动节",
+            "date": "2026-05-03",
+            "isOffDay": true
+        },
+        {
+            "name": "劳动节",
+            "date": "2026-05-04",
+            "isOffDay": true
+        },
+        {
+            "name": "劳动节",
+            "date": "2026-05-05",
+            "isOffDay": true
+        },
+        {
+            "name": "劳动节",
+            "date": "2026-05-09",
+            "isOffDay": false
+        },
+        {
+            "name": "端午节",
+            "date": "2026-06-19",
+            "isOffDay": true
+        },
+        {
+            "name": "端午节",
+            "date": "2026-06-20",
+            "isOffDay": true
+        },
+        {
+            "name": "端午节",
+            "date": "2026-06-21",
+            "isOffDay": true
+        },
+        {
+            "name": "国庆节",
+            "date": "2026-09-20",
+            "isOffDay": false
+        },
+        {
+            "name": "中秋节",
+            "date": "2026-09-25",
+            "isOffDay": true
+        },
+        {
+            "name": "中秋节",
+            "date": "2026-09-26",
+            "isOffDay": true
+        },
+        {
+            "name": "中秋节",
+            "date": "2026-09-27",
+            "isOffDay": true
+        },
+        {
+            "name": "国庆节",
+            "date": "2026-10-01",
+            "isOffDay": true
+        },
+        {
+            "name": "国庆节",
+            "date": "2026-10-02",
+            "isOffDay": true
+        },
+        {
+            "name": "国庆节",
+            "date": "2026-10-03",
+            "isOffDay": true
+        },
+        {
+            "name": "国庆节",
+            "date": "2026-10-04",
+            "isOffDay": true
+        },
+        {
+            "name": "国庆节",
+            "date": "2026-10-05",
+            "isOffDay": true
+        },
+        {
+            "name": "国庆节",
+            "date": "2026-10-06",
+            "isOffDay": true
+        },
+        {
+            "name": "国庆节",
+            "date": "2026-10-07",
+            "isOffDay": true
+        },
+        {
+            "name": "国庆节",
+            "date": "2026-10-10",
+            "isOffDay": false
+        }
+    ]
+}


### PR DESCRIPTION
需求：法定节假日不需要邀请码，周一至周五 09:00–18:00 强制邀请码。

这件事必须放后端。前端只能决定「要不要显示那个输入框」，而
POST /passport/auth/register 是公开接口谁都能直接打；前端还依赖用户
设备时钟，改个系统时间就绕过了。而且中国法定节假日每年由国务院办公厅
发布、含调休，算不出来只能查表。

新增 app/Services/RegisterPolicyService：
- inviteForce() 是唯一判定入口，CommController 和 AuthController 都调它， 前端界面和后端校验用同一个结果，不会出现「界面说不用填、提交被拒」。
- 后台原有的 invite_force 开关当总闸：关掉整套规则不生效，出问题能一键回退。
- 时区写死 Asia/Shanghai。服务器在境外，靠 date() 默认时区会差 12 小时以上。
- 节假日数据读 storage/app/holidays/{年}.json，格式同 holiday-cn。 不在注册接口里同步调第三方 API —— 那会让注册变慢，对方一挂注册跟着挂。
- 只缓存成功结果。读失败也缓存的话，补上文件或改好权限后还得等一整天 才生效，排查时很容易被绕进去；失败会写 Log::warning 说明是路径还是权限。
- inviteForce() 收一个可选的时间参数，只给测试用，生产调用行为不变。

AuthController 里 invite_force 有两处判断，都要改：第 57 行管「没填码」， 第 89 行管「填了但码无效」。只改前一处的话，不强制的时段填错码照样被拒。

附 2026 年节假日数据（33 个放假日 + 6 个调休上班日）。
每年 12 月国务院发文后更新一次即可。

验证：三个文件 php -l 通过；另写独立测试 stub 掉 config/Cache/Log，
用真实 2026 数据跑了 18 个用例全过 —— 覆盖时间窗边界（08:59/09:00/
17:59/18:00）、周末、真实节假日、调休补班日、总闸关闭、UTC 服务器下的
时区换算、缓存命中、以及数据文件缺失时的降级。


Claude-Session: https://claude.ai/code/session_01JSK43Ttp12AGRbhq1y1GvW